### PR TITLE
refresh_token grant doesn't require client creds

### DIFF
--- a/manage/manager.go
+++ b/manage/manager.go
@@ -324,10 +324,15 @@ func (m *Manager) GenerateAccessToken(gt oauth2.GrantType, tgr *oauth2.TokenGene
 
 // RefreshAccessToken refreshing an access token
 func (m *Manager) RefreshAccessToken(tgr *oauth2.TokenGenerateRequest) (oauth2.TokenInfo, error) {
+	if tgr.ClientID == "" {
+		return nil, errors.ErrInvalidClient
+	}
 	cli, err := m.GetClient(tgr.ClientID)
 	if err != nil {
 		return nil, err
-	} else if tgr.ClientSecret != cli.GetSecret() {
+	} else if tgr.ClientSecret != "" && tgr.ClientSecret != cli.GetSecret() {
+		// if a clientSecret was sent, verify that as well to at least quasi-match the OAuth2 spec.
+		// Making this optional is the hack that allows public clients to use refresh tokens.
 		return nil, errors.ErrInvalidClient
 	}
 

--- a/server/handler.go
+++ b/server/handler.go
@@ -48,7 +48,7 @@ func ClientFormHandler(r *http.Request) (string, string, error) {
 	clientID := r.Form.Get("client_id")
 	clientSecret := r.Form.Get("client_secret")
 	if clientID == "" || clientSecret == "" {
-		return "", "", errors.ErrInvalidClient
+		return clientID, clientSecret, errors.ErrInvalidClient
 	}
 	return clientID, clientSecret, nil
 }
@@ -57,7 +57,7 @@ func ClientFormHandler(r *http.Request) (string, string, error) {
 func ClientBasicHandler(r *http.Request) (string, string, error) {
 	username, password, ok := r.BasicAuth()
 	if !ok {
-		return "", "", errors.ErrInvalidClient
+		return username, password, errors.ErrInvalidClient
 	}
 	return username, password, nil
 }


### PR DESCRIPTION
This is a quick hack to allow for clients that are a hybrid of
confidential and public, where a trusted backend is used for the
authorization code flow while the refresh token (and access token(s))
are stored in a public client (single-page app, CLI, etc).

The proper way to address this would be for the oauth2 library to have
first-class support for public clients, including PKCE. This commit
instead accepts a slight hit to the security posture while making it
possible for such hybrid clients to use the refresh token flow.